### PR TITLE
Fix so demo and README both use lib/

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This demo project demonstrates an ES6 jspm workflow:
 
 1. Write ES6 modules and load external modules from CDN
    * Clone this repo, and open `test.html`.
-   * This HTML file runs `System.import('app/main')`.
-   * We are dynamically loading jQuery from CDN and running an ES6 module load.
-   * See [`app/main.js`](https://github.com/jspm/demo-es6/blob/master/app/main.js) and [`app/myclass.js`](https://github.com/jspm/demo-es6/blob/master/app/my-class.js) for the ES6 module files being loaded dynamically in the browser.
+   * This HTML file runs `System.import('lib/main')`.
+   * We are dynamically loading jQuery from `jspm.io`'s `github` endpoint (as defined in `config.js`), and running an ES6 module load.
+   * See [`lib/main.js`](https://github.com/jspm/demo-es6/blob/master/lib/main.js) and [`lib/myclass.js`](https://github.com/jspm/demo-es6/blob/master/lib/my-class.js) for the ES6 module files being loaded dynamically in the browser.
 
 2. Install external modules locally instead of using CDN versions
    * Install jspm: `npm install jspm -g`.
@@ -17,9 +17,9 @@ This demo project demonstrates an ES6 jspm workflow:
    * We are now loading jQuery from the locally installed version, no other configuration or code changes being necessary for this switch.
 
 3. Bundle into a single file for production
-   * Run `jspm bundle app/main --inject`.
-   * This creates a file `build.js` containing all dependencies needed for `app/main` to run.
-   * `--inject` sets the bundle to load automatically when a module is requested from it.
+   * Run `jspm bundle lib/main --inject`.
+   * This creates a file `build.js` containing all dependencies needed for `lib/main` to run; a source map is also created.
+   * `--inject` adds the bundle definition to `config.js`; the appropriate bundle is then loaded automatically when a module is requested from it.
    * We could alternatively use `<script src="build.js"></script>` after SystemJS but before the import.
    * All code is now loaded fully compiled from the single bundle.
 

--- a/config.js
+++ b/config.js
@@ -2,8 +2,7 @@ System.config({
   "paths": {
     "*": "*.js",
     "github:*": "https://github.jspm.io/*.js",
-    "npm:*": "https://npm.jspm.io/*.js",
-    "app/*": "lib/*.js"
+    "npm:*": "https://npm.jspm.io/*.js"
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "registry": "jspm",
-  "main": "app/main",
+  "main": "lib/main",
   "directories": {
     "lib": "lib"
   },
   "dependencies": {
-    "jquery": "^2.0.3"
+    "jquery": "^2.1.1"
   }
 }

--- a/test.html
+++ b/test.html
@@ -11,7 +11,7 @@
   <body>
     <script src='config.js'></script>
     <script>
-      System.import('app/main');
+      System.import('lib/main');
     </script>
   </body>
 </html>


### PR DESCRIPTION
Replaces #10 as discussed there. I think this is now correct. I also updated the JQuery version no in `package.json` to be the same as in `config.js`, as I think it's likely to confuse newbies if they see a different version being loaded after they've installed locally.